### PR TITLE
#37 feat: добавить глобальный фильтр ошибок (404/409/413)

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,9 +1,4 @@
-import {
-  ConflictException,
-  Inject,
-  Injectable,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { CreateAuthDto } from './dto/create-auth.dto';
 import { UpdateAuthDto } from './dto/update-auth.dto';
 import { RegisterDto } from './dto/register.dto';
@@ -41,24 +36,13 @@ export class AuthService {
   }
 
   async register(registerDto: RegisterDto) {
-    try {
-      const salt = this.appConfig.hashSalt;
+    const salt = this.appConfig.hashSalt;
+    const hashedPassword = await bcrypt.hash(registerDto.password, salt);
 
-      const hashedPassword = await bcrypt.hash(registerDto.password, salt);
-
-      return await this.usersService.create({
-        ...registerDto,
-        password: hashedPassword,
-      });
-    } catch (error) {
-      if (error.code === '23505') {
-        throw new ConflictException(
-          'Пользователь с таким email уже существует',
-        );
-      }
-
-      throw error;
-    }
+    return this.usersService.create({
+      ...registerDto,
+      password: hashedPassword,
+    });
   }
 
   async login(loginDto: LoginDto) {

--- a/src/common/constants/error-messages.ts
+++ b/src/common/constants/error-messages.ts
@@ -1,0 +1,6 @@
+export const ERROR_MESSAGES = {
+  ENTITY_NOT_FOUND: 'Сущность не найдена',
+  DUPLICATE: 'Запись с такими данными уже существует',
+  FILE_TOO_LARGE: 'Слишком большой файл',
+  INTERNAL: 'Internal server error',
+} as const;

--- a/src/common/filters/global-exception.filter.ts
+++ b/src/common/filters/global-exception.filter.ts
@@ -1,0 +1,81 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  PayloadTooLargeException,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import { EntityNotFoundError } from 'typeorm';
+import { ERROR_MESSAGES } from '../constants/error-messages';
+
+type PostgresErrorLike = {
+  code?: string;
+  message?: string;
+  detail?: string;
+};
+
+@Catch()
+export class GlobalExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const res = ctx.getResponse<Response>();
+    const req = ctx.getRequest<Request>();
+
+    if (exception instanceof EntityNotFoundError) {
+      return this.reply(res, req, HttpStatus.NOT_FOUND, {
+        message: ERROR_MESSAGES.ENTITY_NOT_FOUND,
+      });
+    }
+
+    if (exception instanceof PayloadTooLargeException) {
+      return this.reply(res, req, HttpStatus.PAYLOAD_TOO_LARGE, {
+        message: ERROR_MESSAGES.FILE_TOO_LARGE,
+      });
+    }
+
+    const pgCode = this.getPostgresCode(exception);
+    if (pgCode === '23505') {
+      return this.reply(res, req, HttpStatus.CONFLICT, {
+        message: ERROR_MESSAGES.DUPLICATE,
+      });
+    }
+
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      const body = exception.getResponse();
+      const payload = typeof body === 'string' ? { message: body } : body;
+
+      return this.reply(res, req, status, payload as Record<string, any>);
+    }
+
+    return this.reply(res, req, HttpStatus.INTERNAL_SERVER_ERROR, {
+      message: ERROR_MESSAGES.INTERNAL,
+    });
+  }
+
+  private getPostgresCode(exception: unknown): string | undefined {
+    if (!exception || typeof exception !== 'object') return undefined;
+
+    const anyEx = exception as {
+      code?: string;
+      driverError?: PostgresErrorLike;
+    };
+    return anyEx.code ?? anyEx.driverError?.code;
+  }
+
+  private reply(
+    res: Response,
+    req: Request,
+    statusCode: number,
+    payload: Record<string, any>,
+  ): void {
+    res.status(statusCode).json({
+      statusCode,
+      timestamp: new Date().toISOString(),
+      path: req.url,
+      ...payload,
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,15 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
   app.useGlobalPipes(new ValidationPipe({ transform: true }));
+  app.useGlobalFilters(new GlobalExceptionFilter());
+
   await app.listen(process.env.PORT ?? 3000);
 }
+
 bootstrap();


### PR DESCRIPTION
- Добавлен глобальный фильтр ошибок GlobalExceptionFilter
- Реализованы обработчики: EntityNotFoundError, Postgres 23505, PayloadTooLargeException
- Убран try/catch на 23505 из AuthService.register, чтобы ошибка обрабатывалась фильтром.

Closes #37 