### PR TITLE
feat: add test skills seeding (#88)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "seed:admin": "ts-node -r tsconfig-paths/register src/seeding/admin.seed.ts",
-    "seed:categories": "ts-node -r tsconfig-paths/register src/seeding/categories.seed.ts"
+    "seed:categories": "ts-node -r tsconfig-paths/register src/seeding/categories.seed.ts",
+    "seed:skills": "ts-node -r tsconfig-paths/register src/seeding/skills.seed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/src/seeding/skills.data.ts
+++ b/src/seeding/skills.data.ts
@@ -1,0 +1,6 @@
+import { CategoriesData } from './categories.data';
+
+// Собираем все дочерние категории (навыки) в один плоский массив
+export const skillNames: string[] = CategoriesData.flatMap(
+  (category) => category.children,
+);

--- a/src/seeding/skills.seed.ts
+++ b/src/seeding/skills.seed.ts
@@ -1,0 +1,71 @@
+import * as dotenv from 'dotenv';
+import { AppDataSource } from '../config/ormconfig';
+import { User } from '../users/entities/user.entity';
+import { Skill } from '../skills/entities/skill.entity';
+import { skillNames } from './skills.data';
+import { UserRole } from '../users/entities/user.enums';
+
+dotenv.config();
+
+async function seedSkills() {
+  try {
+    await AppDataSource.initialize();
+    console.log('Database connected');
+
+    const userRepository = AppDataSource.getRepository(User);
+    const skillRepository = AppDataSource.getRepository(Skill);
+
+    const users = await userRepository.find({
+      where: { role: UserRole.USER },
+    });
+
+    if (users.length === 0) {
+      console.log('No users found. Please run users seeding first.');
+      process.exit(0);
+    }
+
+    console.log(`Found ${users.length} users. Starting skills seeding...`);
+
+    let createdCount = 0;
+    let skippedCount = 0;
+
+    for (const skillName of skillNames) {
+      const existingSkill = await skillRepository.findOne({
+        where: { title: skillName },
+      });
+
+      if (existingSkill) {
+        skippedCount++;
+        continue;
+      }
+
+      const randomUser = users[Math.floor(Math.random() * users.length)];
+
+      const skill = new Skill();
+      skill.title = skillName;
+      skill.owner = randomUser;
+      skill.description = '';
+      skill.images = [];
+
+      await skillRepository.save(skill);
+      createdCount++;
+      console.log(
+        `Skill "${skillName}" created and assigned to ${randomUser.name}`,
+      );
+    }
+
+    console.log(
+      `Skills seeding completed. Created: ${createdCount}, Skipped (already exist): ${skippedCount}`,
+    );
+  } catch (error) {
+    console.error('Error during skills seeding:', error);
+  } finally {
+    await AppDataSource.destroy();
+    process.exit(0);
+  }
+}
+
+seedSkills().catch((error) => {
+  console.error('Unhandled error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
Add seeding script for test skills based on existing categories data.

Changes:
- `src/seeding/skills.data.ts` — extract skill names from categories.data.ts
- `src/seeding/skills.seed.ts` — seeding script that creates a skill for each unique name and assigns it to a random test user
- `package.json` — added `seed:skills` script