### PR TITLE
feat: protect categories endpoints with admin guard

### DIFF
--- a/src/categories/categories.controller.spec.ts
+++ b/src/categories/categories.controller.spec.ts
@@ -1,11 +1,9 @@
-import { NotFoundException, ForbiddenException } from "@nestjs/common";
-import { TestingModule, Test } from "@nestjs/testing";
-import { AuthRequest } from "src/auth/types/auth.types";
-import { UserRole } from "src/users/enums/user.enums";
-import { CategoriesController } from "./categories.controller";
-import { CategoriesService } from "./categories.service";
-import { CreateCategoryDto } from "./dto/create-category.dto";
-import { UpdateCategoryDto } from "./dto/update-category.dto";
+import { NotFoundException } from '@nestjs/common';
+import { TestingModule, Test } from '@nestjs/testing';
+import { CategoriesController } from './categories.controller';
+import { CategoriesService } from './categories.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
 
 const mockCategoriesService = () => ({
   create: jest.fn(),
@@ -14,9 +12,6 @@ const mockCategoriesService = () => ({
   update: jest.fn(),
   remove: jest.fn(),
 });
-
-const makeAuthRequest = (role: UserRole): AuthRequest =>
-  ({ user: { id: 'user-uuid', role } }) as unknown as AuthRequest;
 
 describe('CategoriesController', () => {
   let controller: CategoriesController;
@@ -46,7 +41,12 @@ describe('CategoriesController', () => {
   describe('create', () => {
     it('должен вызвать service.create и вернуть результат', async () => {
       const dto: CreateCategoryDto = { name: 'IT и программирование' };
-      const expected = { id: 'uuid-1', name: dto.name, parent: null, children: [] };
+      const expected = {
+        id: 'uuid-1',
+        name: dto.name,
+        parent: null,
+        children: [],
+      };
 
       service.create.mockResolvedValue(expected);
 
@@ -57,7 +57,10 @@ describe('CategoriesController', () => {
     });
 
     it('должен создать дочернюю категорию при наличии parentId', async () => {
-      const dto: CreateCategoryDto = { name: 'Backend', parentId: 'parent-uuid' };
+      const dto: CreateCategoryDto = {
+        name: 'Backend',
+        parentId: 'parent-uuid',
+      };
       const expected = {
         id: 'child-uuid',
         name: dto.name,
@@ -120,14 +123,21 @@ describe('CategoriesController', () => {
         new NotFoundException('Category with ID bad-uuid not found'),
       );
 
-      await expect(controller.findOne('bad-uuid')).rejects.toThrow(NotFoundException);
+      await expect(controller.findOne('bad-uuid')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
   describe('update', () => {
     it('должен обновить категорию и вернуть результат', async () => {
       const dto: UpdateCategoryDto = { name: 'Обновлённое название' };
-      const expected = { id: 'uuid-1', name: dto.name, parent: null, children: [] };
+      const expected = {
+        id: 'uuid-1',
+        name: dto.name,
+        parent: null,
+        children: [],
+      };
 
       service.update.mockResolvedValue(expected);
 
@@ -140,9 +150,9 @@ describe('CategoriesController', () => {
     it('должен пробросить NotFoundException если категория не найдена', async () => {
       service.update.mockRejectedValue(new NotFoundException());
 
-      await expect(controller.update('bad-uuid', { name: 'X' })).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        controller.update('bad-uuid', { name: 'X' }),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it('должен пробросить NotFoundException при невалидном parentId', async () => {
@@ -155,33 +165,23 @@ describe('CategoriesController', () => {
   });
 
   describe('remove', () => {
-    it('должен удалить категорию если пользователь admin', async () => {
+    it('должен удалить категорию', async () => {
       const expected = { message: 'Категория "IT" успешно удалена' };
 
       service.remove.mockResolvedValue(expected);
 
-      const result = await controller.remove('uuid-1', makeAuthRequest(UserRole.ADMIN));
+      const result = await controller.remove('uuid-1');
 
-      expect(service.remove).toHaveBeenCalledWith('uuid-1', UserRole.ADMIN);
+      expect(service.remove).toHaveBeenCalledWith('uuid-1');
       expect(result).toEqual(expected);
-    });
-
-    it('должен пробросить ForbiddenException если пользователь не admin', async () => {
-      service.remove.mockRejectedValue(
-        new ForbiddenException('Только администратор может удалять категории'),
-      );
-
-      await expect(
-        controller.remove('uuid-1', makeAuthRequest(UserRole.USER)),
-      ).rejects.toThrow(ForbiddenException);
     });
 
     it('должен пробросить NotFoundException если категория не найдена', async () => {
       service.remove.mockRejectedValue(new NotFoundException());
 
-      await expect(
-        controller.remove('bad-uuid', makeAuthRequest(UserRole.ADMIN)),
-      ).rejects.toThrow(NotFoundException);
+      await expect(controller.remove('bad-uuid')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -7,13 +7,11 @@ import {
   Param,
   Delete,
   UseGuards,
-  Req,
 } from '@nestjs/common';
 import { CategoriesService } from './categories.service';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
-import { AuthRequest } from 'src/auth/types/auth.types';
 import {
   ApiCreateCategory,
   ApiGetAllCategories,
@@ -30,7 +28,6 @@ export class CategoriesController {
   constructor(private readonly categoriesService: CategoriesService) {}
 
   @Post()
-  // мне кажется сюда тоже нужно добавить гарду - @UseGuards(JwtAuthGuard)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ADMIN)
   @ApiCreateCategory()
@@ -51,7 +48,8 @@ export class CategoriesController {
   }
 
   @Patch(':id')
-  // и сюда тоже можно добавить - @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
   @ApiUpdateCategory()
   update(
     @Param('id') id: string,
@@ -61,9 +59,10 @@ export class CategoriesController {
   }
 
   @Delete(':id')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
   @ApiDeleteCategory()
-  remove(@Param('id') id: string, @Req() req: AuthRequest) {
-    return this.categoriesService.remove(id, req.user.role);
+  remove(@Param('id') id: string) {
+    return this.categoriesService.remove(id);
   }
 }

--- a/src/categories/categories.service.spec.ts
+++ b/src/categories/categories.service.spec.ts
@@ -82,7 +82,10 @@ describe('CategoriesService', () => {
       expect(repository.findOne).toHaveBeenCalledWith({
         where: { id: parent.id },
       });
-      expect(repository.create).toHaveBeenCalledWith({ name: dto.name, parent });
+      expect(repository.create).toHaveBeenCalledWith({
+        name: dto.name,
+        parent,
+      });
       expect(result).toEqual(child);
     });
 
@@ -156,7 +159,9 @@ describe('CategoriesService', () => {
 
     it('должен выбросить NotFoundException если категория не найдена', async () => {
       repository.findOne!.mockResolvedValue(null);
-      await expect(service.findOne('bad-uuid')).rejects.toThrow(NotFoundException);
+      await expect(service.findOne('bad-uuid')).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('должен передать id в текст ошибки', async () => {
@@ -186,12 +191,14 @@ describe('CategoriesService', () => {
       const parent = makeCategory({ id: 'parent-uuid', name: 'Технологии' });
       const withParent = makeCategory({ parent });
 
-      repository.findOne!
-        .mockResolvedValueOnce({ ...existing })
+      repository
+        .findOne!.mockResolvedValueOnce({ ...existing })
         .mockResolvedValueOnce(parent);
       repository.save!.mockResolvedValue(withParent);
 
-      const result = await service.update('uuid-1', { parentId: 'parent-uuid' });
+      const result = await service.update('uuid-1', {
+        parentId: 'parent-uuid',
+      });
 
       expect(result.parent).toEqual(parent);
     });
@@ -230,8 +237,8 @@ describe('CategoriesService', () => {
     });
 
     it('должен выбросить NotFoundException если новый parentId не найден', async () => {
-      repository.findOne!
-        .mockResolvedValueOnce(makeCategory())
+      repository
+        .findOne!.mockResolvedValueOnce(makeCategory())
         .mockResolvedValueOnce(null);
 
       await expect(
@@ -243,36 +250,22 @@ describe('CategoriesService', () => {
   });
 
   describe('remove', () => {
-    it('должен удалить категорию если пользователь admin', async () => {
+    it('должен удалить категорию', async () => {
       const category = makeCategory({ name: 'IT' });
 
       repository.findOne!.mockResolvedValue(category);
       repository.remove!.mockResolvedValue(category);
 
-      const result = await service.remove('uuid-1', 'admin');
+      const result = await service.remove('uuid-1');
 
       expect(repository.remove).toHaveBeenCalledWith(category);
       expect(result).toEqual({ message: 'Категория "IT" успешно удалена' });
     });
 
-    it('должен выбросить ForbiddenException если пользователь не admin', async () => {
-      await expect(service.remove('uuid-1', 'user')).rejects.toThrow(
-        ForbiddenException,
-      );
-      expect(repository.findOne).not.toHaveBeenCalled();
-      expect(repository.remove).not.toHaveBeenCalled();
-    });
-
-    it('должен выбросить ForbiddenException для роли moderator', async () => {
-      await expect(service.remove('uuid-1', 'moderator')).rejects.toThrow(
-        ForbiddenException,
-      );
-    });
-
     it('должен выбросить NotFoundException если категория не найдена', async () => {
       repository.findOne!.mockResolvedValue(null);
 
-      await expect(service.remove('bad-uuid', 'admin')).rejects.toThrow(
+      await expect(service.remove('bad-uuid')).rejects.toThrow(
         NotFoundException,
       );
       expect(repository.remove).not.toHaveBeenCalled();

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -1,8 +1,4 @@
-import {
-  ForbiddenException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
@@ -100,18 +96,9 @@ export class CategoriesService {
     return this.categoriesRepository.save(category);
   }
 
-  async remove(id: string, userRole: string) {
-    // Проверка прав администратора
-    if (userRole !== 'admin') {
-      throw new ForbiddenException(
-        'Только администратор может удалять категории',
-      );
-    }
-
+  async remove(id: string) {
     const category = await this.findOne(id);
-
     await this.categoriesRepository.remove(category);
-
     return { message: `Категория "${category.name}" успешно удалена` };
   }
 }


### PR DESCRIPTION
## Описание
Защищены эндпоинты категорий гардой с проверкой роли администратора.

## Изменения
- Добавлены \`@UseGuards(JwtAuthGuard, RolesGuard)\` и \`@Roles(UserRole.ADMIN)\` на методы \`create\`, \`update\`, \`remove\` в \`categories.controller.ts\`
- Убрана проверка роли из \`CategoriesService.remove\` (теперь роль проверяется на уровне гардов)
- Обновлены unit-тесты для контроллера и сервиса
